### PR TITLE
Changed the way the .clang_complete files are loaded

### DIFF
--- a/rplugin/python3/deoplete/source/clangx.py
+++ b/rplugin/python3/deoplete/source/clangx.py
@@ -102,7 +102,7 @@ class Source(Base):
             return []
 
         try:
-            with open(clang_file) as f:
+            with open(context['cwd'] + "/" + clang_file) as f:
                 return shlex.split(' '.join(f.readlines()))
         except Exception as e:
             error(self.vim, 'Parse Failed: ' + clang_file)


### PR DESCRIPTION
I had an issue where it wasn't loading my .clang_complete file correctly since the scripts current working directory was whichever directory Vim was started in. This should fix it, but there might be a nicer way of doing it